### PR TITLE
시간 및 인원 수 직접 입력 : 0보다 작거나 같은 수가 입력될 경우, 1명으로 설정되도록 수정.

### DIFF
--- a/TimerB/Main/Cells/SelectOptionCell.swift
+++ b/TimerB/Main/Cells/SelectOptionCell.swift
@@ -51,7 +51,8 @@ class SelectOptionViewModel: OptionViewModelProtocol {
             
             let originalValue = self.option.currentValue()
             let input = alert.textFields?.first?.text ?? String(originalValue)
-            let number = min(Int(input) ?? originalValue, type.maxNumber)
+            let inputBiggerThanZero = (Int(input) ?? 0) <= 0 ? 1 : Int(input)
+            let number = min(inputBiggerThanZero ?? originalValue, type.maxNumber)
             self.setNumber(with: number)
         }
         


### PR DESCRIPTION
=> 0명은 입력할 수 없도록 함.